### PR TITLE
修复win32平台没有CC_FORMAT_PRINTF宏定义

### DIFF
--- a/cocos/platform/CCPlatformMacros.h
+++ b/cocos/platform/CCPlatformMacros.h
@@ -296,6 +296,8 @@ private: varType varName; public: virtual inline varType get##funName() const { 
 #elif defined(__has_attribute)
   #if __has_attribute(format)
   #define CC_FORMAT_PRINTF(formatPos, argPos) __attribute__((__format__(printf, formatPos, argPos)))
+  #else
+    #define CC_FORMAT_PRINTF(formatPos, argPos)
   #endif // __has_attribute(format)
 #else
 #define CC_FORMAT_PRINTF(formatPos, argPos)


### PR DESCRIPTION
VS2019上提示CCConsole.h等文件有错误，原因是这里没有走进任何一个CC_FORMAT_PRINTF定义分支